### PR TITLE
Fixes #36 - Use a regexp for the URL (rather than substring match)

### DIFF
--- a/bugs.js
+++ b/bugs.js
@@ -53,6 +53,15 @@ function formatDateForAPIQueries(date) {
 }
 
 /**
+ * Returns a domain formatted for Bugzilla URL regexp strings.
+ * @param {String} website
+ */
+function formatWebSiteForRegExp(website) {
+    // We want https?://(.+\.)*example\.com(/.*)*$, in a suitable query string format
+    return encodeURIComponent(`https?://(.+\\.)*${website.replace(/\./g, "\\.")}(/.*)*$`);
+}
+
+/**
  * Returns Bugzilla bugs created after minDate if specified, 2018-01-01 otherwise.
  * @param {String} website
  * @param {String} bugzillaKey
@@ -63,10 +72,10 @@ const getBugzilla = async (website, bugzillaKey, minDate, maxDate) => {
     const minDateQuery = minDate ? formatDateForAPIQueries(minDate) : "2018";
     const maxDateQuery = maxDate ? formatDateForAPIQueries(maxDate) : "";
     const maxDateQueryFragment = maxDate ? `&f4=creation_ts&o4=lessthaneq&v4=${formatDateForAPIQueries(maxDate)}` : "";
-    const openQuery = `https://bugzilla.mozilla.org/buglist.cgi?priority=P1&priority=P2&priority=P3&f1=OP&bug_file_loc_type=allwordssubstr&o3=greaterthaneq&list_id=14636479&v3=${minDateQuery}&resolution=---&bug_file_loc=${website}&query_format=advanced&f3=creation_ts&bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&product=Core&product=Fenix&product=Firefox%20for%20Android&product=Firefox%20for%20Echo%20Show&product=Firefox%20for%20FireTV&product=Firefox%20for%20iOS&product=GeckoView&product=Web%20Compatibility&keywords_type=nowords&keywords=meta%2C%20&status_whiteboard_type=notregexp&status_whiteboard=sci%5C-exclude${maxDateQueryFragment}`;
-    // const resolvedQuery = `https://bugzilla.mozilla.org/buglist.cgi?priority=P1&priority=P2&priority=P3&keywords=meta%2C%20&keywords_type=nowords&list_id=14745792&status_whiteboard_type=notregexp&bug_file_loc=google.com&chfield=bug_status&chfieldfrom=${maxDateQuery}&o4=lessthaneq&chfieldvalue=RESOLVED&status_whiteboard=sci%5C-exclude&v4=${maxDateQuery}&f1=OP&o3=greaterthaneq&bug_file_loc_type=allwordssubstr&v3=${minDateQuery}&f4=creation_ts&query_format=advanced&f3=creation_ts&product=Core&product=Fenix&product=Firefox%20for%20Android&product=Firefox%20for%20Echo%20Show&product=Firefox%20for%20FireTV&product=Firefox%20for%20iOS&product=GeckoView&product=Web%20Compatibility`;
-    const openApiQuery =     `https://bugzilla.mozilla.org/rest/bug?include_fields=id,summary,status,priority&priority=P1&priority=P2&priority=P3&bug_file_loc=${website}&bug_file_loc_type=allwordssubstr&bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&f1=OP&f3=creation_ts&keywords=meta%2C%20&keywords_type=nowords&o3=greaterthaneq&product=Core&product=Fenix&product=Firefox%20for%20Android&product=Firefox%20for%20Echo%20Show&product=Firefox%20for%20FireTV&product=Firefox%20for%20iOS&product=GeckoView&product=Web%20Compatibility&resolution=---&status_whiteboard=sci%5C-exclude&status_whiteboard_type=notregexp&v3=${minDateQuery}&api_key=${bugzillaKey}${maxDateQueryFragment}`;
-    const resolvedApiQuery = `https://bugzilla.mozilla.org/rest/bug?include_fields=id,summary,status,priority&priority=P1&priority=P2&priority=P3&bug_file_loc=${website}&bug_file_loc_type=allwordssubstr&chfield=bug_status&chfieldfrom=${maxDateQuery}&chfieldvalue=RESOLVED&f1=OP&f3=creation_ts&f4=creation_ts&keywords=meta%2C%20&keywords_type=nowords&o3=greaterthaneq&o4=lessthaneq&product=Core&product=Fenix&product=Firefox%20for%20Android&product=Firefox%20for%20Echo%20Show&product=Firefox%20for%20FireTV&product=Firefox%20for%20iOS&product=GeckoView&product=Web%20Compatibility&status_whiteboard=sci%5C-exclude&status_whiteboard_type=notregexp&v3=${minDateQuery}&v4=${maxDateQuery}&api_key=${bugzillaKey}`;
+    const openQuery = `https://bugzilla.mozilla.org/buglist.cgi?priority=P1&priority=P2&priority=P3&f1=OP&bug_file_loc_type=regexp&o3=greaterthaneq&list_id=14636479&v3=${minDateQuery}&resolution=---&bug_file_loc=${formatWebSiteForRegExp(website)}&query_format=advanced&f3=creation_ts&bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&product=Core&product=Fenix&product=Firefox%20for%20Android&product=Firefox%20for%20Echo%20Show&product=Firefox%20for%20FireTV&product=Firefox%20for%20iOS&product=GeckoView&product=Web%20Compatibility&keywords_type=nowords&keywords=meta%2C%20&status_whiteboard_type=notregexp&status_whiteboard=sci%5C-exclude${maxDateQueryFragment}`;
+    // const resolvedQuery = `https://bugzilla.mozilla.org/buglist.cgi?priority=P1&priority=P2&priority=P3&keywords=meta%2C%20&keywords_type=nowords&list_id=14745792&status_whiteboard_type=notregexp&bug_file_loc=google.com&chfield=bug_status&chfieldfrom=${maxDateQuery}&o4=lessthaneq&chfieldvalue=RESOLVED&status_whiteboard=sci%5C-exclude&v4=${maxDateQuery}&f1=OP&o3=greaterthaneq&bug_file_loc_type=regexp&v3=${minDateQuery}&f4=creation_ts&query_format=advanced&f3=creation_ts&product=Core&product=Fenix&product=Firefox%20for%20Android&product=Firefox%20for%20Echo%20Show&product=Firefox%20for%20FireTV&product=Firefox%20for%20iOS&product=GeckoView&product=Web%20Compatibility`;
+    const openApiQuery =     `https://bugzilla.mozilla.org/rest/bug?include_fields=id,summary,status,priority&priority=P1&priority=P2&priority=P3&bug_file_loc=${formatWebSiteForRegExp(website)}&bug_file_loc_type=regexp&bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&f1=OP&f3=creation_ts&keywords=meta%2C%20&keywords_type=nowords&o3=greaterthaneq&product=Core&product=Fenix&product=Firefox%20for%20Android&product=Firefox%20for%20Echo%20Show&product=Firefox%20for%20FireTV&product=Firefox%20for%20iOS&product=GeckoView&product=Web%20Compatibility&resolution=---&status_whiteboard=sci%5C-exclude&status_whiteboard_type=notregexp&v3=${minDateQuery}&api_key=${bugzillaKey}${maxDateQueryFragment}`;
+    const resolvedApiQuery = `https://bugzilla.mozilla.org/rest/bug?include_fields=id,summary,status,priority&priority=P1&priority=P2&priority=P3&bug_file_loc=${formatWebSiteForRegExp(website)}&bug_file_loc_type=regexp&chfield=bug_status&chfieldfrom=${maxDateQuery}&chfieldvalue=RESOLVED&f1=OP&f3=creation_ts&f4=creation_ts&keywords=meta%2C%20&keywords_type=nowords&o3=greaterthaneq&o4=lessthaneq&product=Core&product=Fenix&product=Firefox%20for%20Android&product=Firefox%20for%20Echo%20Show&product=Firefox%20for%20FireTV&product=Firefox%20for%20iOS&product=GeckoView&product=Web%20Compatibility&status_whiteboard=sci%5C-exclude&status_whiteboard_type=notregexp&v3=${minDateQuery}&v4=${maxDateQuery}&api_key=${bugzillaKey}`;
     const promiseFn = () => fetch(openApiQuery);
     const options = {
         times: 3,
@@ -251,7 +260,7 @@ function getSeeAlsoLinks(bug) {
  * @param {*} githubKey
  */
 const getDuplicates = async (website, bugzillaKey, githubKey, minDate, maxDate) => {
-    const apiQuery = `https://bugzilla.mozilla.org/rest/bug?include_fields=id,creation_time,see_also,history,priority&priority=P1&priority=P2&priority=P3&f1=see_also&f2=bug_status&f3=bug_file_loc&o1=anywordssubstr&o2=anywordssubstr&o3=casesubstring&v1=webcompat.com%2Cgithub.com%2Fwebcompat&v2=UNCONFIRMED%2CNEW%2CASSIGNED%2CREOPENED&v3=${website}&limit=0&api_key=${bugzillaKey}`
+    const apiQuery = `https://bugzilla.mozilla.org/rest/bug?include_fields=id,creation_time,see_also,history,priority&priority=P1&priority=P2&priority=P3&f1=see_also&f2=bug_status&f3=bug_file_loc&o1=anywordssubstr&o2=anywordssubstr&o3=regexp&v1=webcompat.com%2Cgithub.com%2Fwebcompat&v2=UNCONFIRMED%2CNEW%2CASSIGNED%2CREOPENED&v3=${formatWebSiteForRegExp(website)}&limit=0&api_key=${bugzillaKey}`
     const promiseFn = () => fetch(apiQuery);
     const options = {
         times: 3,


### PR DESCRIPTION
This won't be bulletproof, but it should prevent the case of t.co
matching something like pot.com

I did a run of the Top 50 for today here: https://docs.google.com/spreadsheets/d/1EU_7rLZq3dNMmDTnVDOzYgyP9z0KtNO9Sb2gCbm1KGU/edit?ts=5cfae36d#gid=1390534225

I want to review the results before requesting review though.