### PR TITLE
Append to an existing spreadsheet if a spreadsheetId is provided (fix…

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ would look like:
   // A cutoff date for calculating the TSCI (if not a Sunday, will be rounded to the next Sunday).
   // E.g. a value of "2019-03-01" would lead to using "2019-03-03" (March 1st was a Friday).
   "maxDate": null,
+  // The ID of a spreadsheet to append to.
+  "spreadsheetId": null,
   // A list of Google accounts with whom the final spreadsheet should be shared.
   "writers": [
     "user@example.com"

--- a/config.json.example
+++ b/config.json.example
@@ -9,6 +9,7 @@
     "t.co"
   ],
   "maxDate": null,
+  "spreadsheetId": null,
   "writers": [
     "user@example.com"
   ]

--- a/spreadsheet.js
+++ b/spreadsheet.js
@@ -10,7 +10,7 @@ async function createSpreadsheet(sheets, title, maxDate) {
     const { data } = await sheets.spreadsheets.create({ resource });
     const spreadsheetId = data.spreadsheetId;
     const sheetId = data.sheets[0].properties.sheetId;
-    // Cosntruct the sheet title.
+    // Construct the sheet title.
     const sheetTitle = getSheetTitle(maxDate);
     // Fix sheet name.
     await sheets.spreadsheets.batchUpdate({
@@ -91,7 +91,7 @@ async function findOrCreateSheet(sheets, spreadsheetId, maxDate) {
     let result = await sheets.spreadsheets.get({
         spreadsheetId,
     });
-    // Cosntruct the sheet title.
+    // Construct the sheet title.
     const title = getSheetTitle(maxDate);
 
     // Find the sheet to update...


### PR DESCRIPTION
…es #18)

One more change: in the default case where no `spreadsheetId` is provided, the script no longer imports the tranco CSV file, but adds the cells as part of the `addStaticData` method.